### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,14 +1,14 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!,only: [:new, :create]
-  
+  before_action :authenticate_user!, only: [:new, :create]
+
   def index
-    @items = Item.includes(:user).order(created_at: "DESC")
+    @items = Item.includes(:user).order(created_at: 'DESC')
   end
-  
+
   def new
     @item = Item.new
   end
-  
+
   def create
     @item = Item.new(item_params)
     if @item.save
@@ -17,10 +17,15 @@ class ItemsController < ApplicationController
       render new_item_path
     end
   end
-  
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
-  
+
   def item_params
-    params.require(:item).permit(:name, :text, :category_id, :status_id, :cost_who_id, :post_from_id, :days_to_post_id, :price, :image).merge(user_id: current_user.id)
-  end 
+    params.require(:item).permit(:name, :text, :category_id, :status_id, :cost_who_id, :post_from_id, :days_to_post_id, :price,
+                                 :image).merge(user_id: current_user.id)
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,8 +12,7 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/cost_who.rb
+++ b/app/models/cost_who.rb
@@ -4,8 +4,7 @@ class CostWho < ActiveHash::Base
     { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
-    
+
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/days_to_post.rb
+++ b/app/models/days_to_post.rb
@@ -5,8 +5,7 @@ class DaysToPost < ActiveHash::Base
     { id: 3, name: '2~3日で発送' },
     { id: 4, name: '4~7日で発送' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,8 @@ class Item < ApplicationRecord
     validates :image
     validates :name
     validates :text
-    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}, format: { with: /\A[0-9]+\z/, message: 'is invalid. Input half-width characters' }
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
+                      format: { with: /\A[0-9]+\z/, message: 'is invalid. Input half-width characters' }
   end
   with_options presence: true, numericality: { other_than: 1 } do
     validates :category_id
@@ -12,14 +13,14 @@ class Item < ApplicationRecord
     validates :post_from_id
     validates :days_to_post_id
   end
-  
+
   belongs_to :user
   has_one_attached :image
-  
+
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :status
   belongs_to :cost_who
-  belongs_to :post_from  
+  belongs_to :post_from
   belongs_to :days_to_post
 end

--- a/app/models/post_from.rb
+++ b/app/models/post_from.rb
@@ -49,8 +49,7 @@ class PostFrom < ActiveHash::Base
     { id: 47, name: '鹿児島県' },
     { id: 48, name: '沖縄県' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -8,8 +8,7 @@ class Status < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,14 +3,14 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
+
   validates :password,
-             format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'is invalid. Include both letters and numbers' }
+            format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'is invalid. Include both letters and numbers' }
   with_options presence: true do
-   validates :nickname   
-   validates :last_name, :first_name, format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/ }
-   validates :last_name_kana, :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
-   validates :birthday
+    validates :nickname
+    validates :last_name, :first_name, format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/ }
+    validates :last_name_kana, :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
+    validates :birthday
   end
-  has_many :items  
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,25 +16,26 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.cost_who.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && @item.user.id == current_user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? && @item.user.id != current_user.id %>  
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.cost_who.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.post_from.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_post.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,7 +38,7 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,15 +23,15 @@
       </span>
     </div>
 
-    <% if user_signed_in? && @item.user.id == current_user.id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% end %>
-
+    <% if user_signed_in? %>
+     <% if @item.user.id == current_user.id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+     <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if user_signed_in? && @item.user.id != current_user.id %>  
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+     <% end %>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :show]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     cost_who_id { Faker::Number.between(from: 2, to: 3) }
     post_from_id { Faker::Number.between(from: 2, to: 48) }
     days_to_post_id { Faker::Number.between(from: 2, to: 4) }
-    price { Faker::Number.between(from: 300, to: 9999999) }
-    
+    price { Faker::Number.between(from: 300, to: 9_999_999) }
+
     association :user
 
     after(:build) do |item|

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,117 +2,117 @@ require 'rails_helper'
 
 RSpec.describe Item, type: :model do
   describe '商品投稿機能' do
-   before do
-     @item = FactoryBot.build(:item)
-   end
+    before do
+      @item = FactoryBot.build(:item)
+    end
 
-   context '商品投稿できる時' do
-    it '全ての項目の入力ができていたら投稿できる' do
-      expect(@item).to be_valid
+    context '商品投稿できる時' do
+      it '全ての項目の入力ができていたら投稿できる' do
+        expect(@item).to be_valid
+      end
     end
-   end
 
-   context '商品投稿できない時' do
-    it 'nameが空欄だと投稿できない' do
-      @item.name = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
+    context '商品投稿できない時' do
+      it 'nameが空欄だと投稿できない' do
+        @item.name = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Name can't be blank")
+      end
+      it 'textが空欄だと投稿できない' do
+        @item.text = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Text can't be blank")
+      end
+      it 'category_idが空欄だと投稿できない' do
+        @item.category_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Category can't be blank")
+      end
+      it 'category_idが1だと投稿できない' do
+        @item.category_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
+      end
+      it 'status_idが空欄だと投稿できない' do
+        @item.status_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Status can't be blank")
+      end
+      it 'status_idが1だと投稿できない' do
+        @item.status_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Status must be other than 1')
+      end
+      it 'cost_who_idが空欄だと投稿できない' do
+        @item.cost_who_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Cost who can't be blank")
+      end
+      it 'cost_who_idが1だと投稿できない' do
+        @item.cost_who_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Cost who must be other than 1')
+      end
+      it 'post_from_idが空欄だと投稿できない' do
+        @item.post_from_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Post from can't be blank")
+      end
+      it 'post_from_idが1だと投稿できない' do
+        @item.post_from_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Post from must be other than 1')
+      end
+      it 'days_to_postが空欄だと投稿できない' do
+        @item.days_to_post_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Days to post can't be blank")
+      end
+      it 'days_to_postが1だと投稿できない' do
+        @item.days_to_post_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Days to post must be other than 1')
+      end
+      it 'priceが空欄だと投稿できない' do
+        @item.price = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Price can't be blank")
+      end
+      it 'priceが全角数字だと投稿できない' do
+        @item.price = '５００'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+      it 'priceが299以下だと投稿できない' do
+        @item.price = 299
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+      end
+      it 'priceが10000000以上だと投稿できない' do
+        @item.price = 10_000_000
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
+      end
+      it 'priceが半角英数字混合していると投稿できない' do
+        @item.price = 'abc123'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+      it 'priceが半角英字のみでは投稿できない' do
+        @item.price = 'abcdef'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+      it '画像が添付されていないと投稿できない' do
+        @item.image = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Image can't be blank")
+      end
+      it 'userモデルと紐づいていないと投稿できない' do
+        @item.user = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include('User must exist')
+      end
     end
-    it 'textが空欄だと投稿できない' do
-      @item.text = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Text can't be blank")
-    end
-    it 'category_idが空欄だと投稿できない' do
-      @item.category_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Category can't be blank")
-    end
-    it 'category_idが1だと投稿できない' do
-      @item.category_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Category must be other than 1')
-    end
-    it 'status_idが空欄だと投稿できない' do
-      @item.status_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Status can't be blank")
-    end
-    it 'status_idが1だと投稿できない' do
-      @item.status_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Status must be other than 1')
-    end
-    it 'cost_who_idが空欄だと投稿できない' do
-      @item.cost_who_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Cost who can't be blank")
-    end
-    it 'cost_who_idが1だと投稿できない' do
-      @item.cost_who_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Cost who must be other than 1')
-    end
-    it 'post_from_idが空欄だと投稿できない' do
-      @item.post_from_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Post from can't be blank")
-    end
-    it 'post_from_idが1だと投稿できない' do
-      @item.post_from_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Post from must be other than 1')
-    end
-    it 'days_to_postが空欄だと投稿できない' do
-      @item.days_to_post_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Days to post can't be blank")
-    end
-    it 'days_to_postが1だと投稿できない' do
-      @item.days_to_post_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Days to post must be other than 1')
-    end
-    it 'priceが空欄だと投稿できない' do
-      @item.price = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Price can't be blank")
-    end
-    it 'priceが全角数字だと投稿できない' do
-      @item.price = '５００'
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Price is not a number')
-    end
-    it 'priceが299以下だと投稿できない' do
-      @item.price = 299
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
-    end
-    it 'priceが10000000以上だと投稿できない' do
-      @item.price = 10000000
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
-    end
-    it 'priceが半角英数字混合していると投稿できない' do
-      @item.price = 'abc123'
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Price is not a number')
-    end
-    it 'priceが半角英字のみでは投稿できない' do
-      @item.price = 'abcdef'
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Price is not a number')
-    end
-    it '画像が添付されていないと投稿できない' do
-      @item.image = nil
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
-    end
-    it 'userモデルと紐づいていないと投稿できない' do
-      @item.user = nil
-      @item.valid?
-      expect(@item.errors.full_messages).to include('User must exist')
-    end
-   end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,124 +6,124 @@ RSpec.describe User, type: :model do
       @user = FactoryBot.build(:user)
     end
 
-    context "ユーザー登録できる時" do
-     it '全ての項目が正しく入力されれば登録できる' do
-       expect(@user).to be_valid
-     end
+    context 'ユーザー登録できる時' do
+      it '全ての項目が正しく入力されれば登録できる' do
+        expect(@user).to be_valid
+      end
     end
 
-    context "ユーザー登録できない時" do
-     it 'nicknameが空だと登録できない' do
-       @user.nickname = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Nickname can't be blank")
-     end
-     it 'emailが空だと登録できない' do
-       @user.email = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Email can't be blank")
-     end
-     it 'emailに@が含まれないと登録できない' do
-       @user.email = 'abcdefg'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Email is invalid')
-     end
-     it '同一のemailは登録できない' do
-       @user2 = FactoryBot.create(:user)
-       @user.email = @user2.email
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Email has already been taken')
-     end
-     it 'passwordが空だと登録できない' do
-       @user.password = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Password can't be blank")
-     end
-     it 'passwordが5文字以下だと登録できない' do
-       @user.password = 'a1234'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
-     end
-     it 'passwordが半角数字だけの場合は登録できない' do
-       @user.password = '111111'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
-     end
-     it 'ppasswordが半角英字だけの場合は登録できない' do
-      @user.password = 'aaaaaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
-     end
-     it 'passwordが全角英数字混合の場合は登録できない' do
-      @user.password = 'ｔｓ１２３４'
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
-     end
-     it 'password_confirmationが空だと登録できない' do
-       @user.password_confirmation = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-     end
-     it 'passwordとpassword_confirmationが一致しないと登録できない' do
-       @user.password_confirmation = 'abc123'
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-     end
-     it 'last_nameが空だと登録できない' do
-       @user.last_name = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Last name can't be blank")
-     end
-     it 'last_nameが半角だと登録できない' do
-       @user.last_name = 'ｱｱｱｱ'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Last name is invalid')
-     end
-     it 'first_nameが空だと登録できない' do
-       @user.first_name = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("First name can't be blank")
-     end
-     it 'first_nameが半角だと登録できない' do
-       @user.first_name = 'ｱｱｱｱ'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('First name is invalid')
-     end
-     it 'last_name_kanaが空だと登録できない' do
-       @user.last_name_kana = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Last name kana can't be blank")
-     end
-     it 'last_name_kanaが全角平仮名だと登録できない' do
-       @user.last_name_kana = 'あいうえお'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Last name kana is invalid')
-     end
-     it 'last_name_kanaが半角片仮名だと登録できない' do
-       @user.last_name_kana = 'ｱｲｳｴｵ'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('Last name kana is invalid')
-     end
-     it 'first_name_kanaが空だと登録できない' do
-       @user.first_name_kana = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("First name kana can't be blank")
-     end
-     it 'first_name_kanaが全角平仮名だと登録できない' do
-       @user.first_name_kana = 'あいうえお'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('First name kana is invalid')
-     end
-     it 'first_name_kanaが半角片仮名だと登録できない' do
-       @user.first_name_kana = 'ｱｲｳｴｵ'
-       @user.valid?
-       expect(@user.errors.full_messages).to include('First name kana is invalid')
-     end
-     it 'birthdayが空だと登録できない' do
-       @user.birthday = ''
-       @user.valid?
-       expect(@user.errors.full_messages).to include("Birthday can't be blank")
-     end
+    context 'ユーザー登録できない時' do
+      it 'nicknameが空だと登録できない' do
+        @user.nickname = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      end
+      it 'emailが空だと登録できない' do
+        @user.email = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Email can't be blank")
+      end
+      it 'emailに@が含まれないと登録できない' do
+        @user.email = 'abcdefg'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Email is invalid')
+      end
+      it '同一のemailは登録できない' do
+        @user2 = FactoryBot.create(:user)
+        @user.email = @user2.email
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Email has already been taken')
+      end
+      it 'passwordが空だと登録できない' do
+        @user.password = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password can't be blank")
+      end
+      it 'passwordが5文字以下だと登録できない' do
+        @user.password = 'a1234'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+      end
+      it 'passwordが半角数字だけの場合は登録できない' do
+        @user.password = '111111'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+      end
+      it 'ppasswordが半角英字だけの場合は登録できない' do
+        @user.password = 'aaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+      end
+      it 'passwordが全角英数字混合の場合は登録できない' do
+        @user.password = 'ｔｓ１２３４'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+      end
+      it 'password_confirmationが空だと登録できない' do
+        @user.password_confirmation = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      end
+      it 'passwordとpassword_confirmationが一致しないと登録できない' do
+        @user.password_confirmation = 'abc123'
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      end
+      it 'last_nameが空だと登録できない' do
+        @user.last_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Last name can't be blank")
+      end
+      it 'last_nameが半角だと登録できない' do
+        @user.last_name = 'ｱｱｱｱ'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Last name is invalid')
+      end
+      it 'first_nameが空だと登録できない' do
+        @user.first_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name can't be blank")
+      end
+      it 'first_nameが半角だと登録できない' do
+        @user.first_name = 'ｱｱｱｱ'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name is invalid')
+      end
+      it 'last_name_kanaが空だと登録できない' do
+        @user.last_name_kana = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+      end
+      it 'last_name_kanaが全角平仮名だと登録できない' do
+        @user.last_name_kana = 'あいうえお'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
+      end
+      it 'last_name_kanaが半角片仮名だと登録できない' do
+        @user.last_name_kana = 'ｱｲｳｴｵ'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
+      end
+      it 'first_name_kanaが空だと登録できない' do
+        @user.first_name_kana = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+      end
+      it 'first_name_kanaが全角平仮名だと登録できない' do
+        @user.first_name_kana = 'あいうえお'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
+      end
+      it 'first_name_kanaが半角片仮名だと登録できない' do
+        @user.first_name_kana = 'ｱｲｳｴｵ'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
+      end
+      it 'birthdayが空だと登録できない' do
+        @user.birthday = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+      end
     end
   end
 end

--- a/spec/requests/items_request_spec.rb
+++ b/spec/requests/items_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Items", type: :request do
-
+RSpec.describe 'Items', type: :request do
 end


### PR DESCRIPTION
## what

- 投稿された商品の詳細情報表示機能実装
- ユーザーの種類毎に操作できるボタンの表示を変更

## why

- 登録された詳しい情報をユーザーが閲覧する為
- ユーザーの種類により操作できる範囲を制限する為

## 画像・動画

- [出品者](https://gyazo.com/9f45ba5dc47c49aaa1f41799fd85880d)
- [出品者以外のユーザー](https://gyazo.com/2ecd450806a0cf48c770669717693f13)
- [ログインしていないユーザー](https://gyazo.com/4e4c1f9d86f997014530b863218af281)

## 補足

- 商品購入機能は未実装